### PR TITLE
docs: remove dead vendor link from supporting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,7 +955,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 💝 Supporting This Project
 
-If you find Client St0r useful for your MSP or IT department, please consider supporting the developer's business: **[MSP Reboot](https://www.mspreboot.com)** - Professional MSP services and consulting.
+If you find Client St0r useful for your MSP or IT department, please consider starring the repository and sharing it with your team.
 
 Your support allows me to continue developing open-source tools like Client St0r and contribute to the MSP community. Thank you!
 


### PR DESCRIPTION
## What
The supporting section promoted the developer's business site mspreboot.com, which no longer resolves. I replaced that sentence with a neutral one about starring and sharing the repo, so the section still makes sense.

## Why
DNS lookup for www.mspreboot.com and mspreboot.com both fail, so the link goes nowhere.

## Verification
Confirmed DNS resolution failure today.